### PR TITLE
Allow shortcuts to replace the list of columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ The following settings are available when defining shortcuts:
 | Setting       | Description |
 |---------------|-------------|
 | `description` | Description of the shortcut (visible in `--help`) |
+| `columns`     | List of columns to display |
 | `add_columns` | Extra columns to append of the default list |
 | `with_fact`   | Extra filtering of the results based on facts |
 | `with_class`  | Extra filtering of the results based on configured classes |

--- a/lib/motoko/option_parser.rb
+++ b/lib/motoko/option_parser.rb
@@ -67,7 +67,11 @@ module Motoko
 
       formatter.shortcuts.each do |key, value|
         parser.on("--#{key}", value.delete('description')) do
-          formatter.columns.push(*value.delete('add_columns'))
+          if value.key?('columns')
+            formatter.columns.replace(value.delete('columns'))
+          else
+            formatter.columns.push(*value.delete('add_columns'))
+          end
           local_options[:with_class] ||= []
           local_options[:with_class].push(*value.delete('with_class'))
           local_options[:with_fact] ||= []

--- a/spec/motoko/option_parser_spec.rb
+++ b/spec/motoko/option_parser_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Motoko::OptionParser do
+  describe '::add_shortcut_options' do
+    let(:parser) { double }
+    let(:formatter) { Motoko::Formatter.new }
+    let(:local_options) { {} }
+    let(:columns) { ['foo'] }
+
+    before do
+      allow(parser).to receive(:separator)
+      allow(parser).to receive(:on).and_yield
+      allow(formatter).to receive(:shortcuts).and_return(shortcuts)
+      allow(formatter).to receive(:columns).and_return(columns)
+      described_class.add_shortcut_options(parser, formatter, local_options)
+    end
+
+    context 'with add_columns' do
+      let(:shortcuts) do
+        { 'test' => { 'description' => 'Unit test', 'add_columns' => %w[bar baz] } }
+      end
+
+      it do
+        expect(parser).to have_received(:on).with('--test', 'Unit test')
+      end
+
+      it do
+        expect(formatter.columns).to eq(%w[foo bar baz])
+      end
+    end
+
+    context 'with columns' do
+      let(:shortcuts) do
+        { 'test' => { 'description' => 'Unit test', 'columns' => %w[bar baz] } }
+      end
+
+      it do
+        expect(parser).to have_received(:on).with('--test', 'Unit test')
+      end
+
+      it do
+        expect(formatter.columns).to eq(%w[bar baz])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is intended to help people have default setting that match their
preverences and allowing them to build totaly custom reports more
easily.